### PR TITLE
Remove superfluous dash in npm command

### DIFF
--- a/apps/docs/pages/guides/spa.mdx
+++ b/apps/docs/pages/guides/spa.mdx
@@ -24,7 +24,7 @@ We solve this in a few different ways, mainly via [hashing](https://content-secu
 <Tabs items={['npm', 'yarn', 'pnpm']} defaultIndex="0">
   <Tabs.Tab>
   ```bash
-npm install -D vite-plugin-csp-guard -
+npm install -D vite-plugin-csp-guard
   ```
   </Tabs.Tab>
   <Tabs.Tab>


### PR DESCRIPTION
Removed seemingly superfluous dash in `npm install` command, which would install the [`-` package from npm](https://www.npmjs.com/package/-). 

Not sure if the dash is deliberate, but since it's not there in the corresponding commands for the other package managers, I'm guessing it's not supposed to be there.
