### PR TITLE
chore(release): bump vite-plugin-csp-guard to v2.2.0

### DIFF
--- a/packages/vite-plugin-csp-guard/package.json
+++ b/packages/vite-plugin-csp-guard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-csp-guard",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "author": {
     "name": "Tsotne Gvadzabia"
   },


### PR DESCRIPTION
# Key Changes

Releases switch to MIT after `csp-toolkit` switches to MIT also  
